### PR TITLE
Allow update database class type & storage size 

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ spec:
   tags: "key=value,key1=value1"
   provider: aws # Optional either aws or local, will overrides the value the operator was started with 
   skipfinalsnapshot: false # Indicates whether to skip the creation of a final DB snapshot before deleting the instance. By default, skipfinalsnapshot isn't enabled, and the DB snapshot is created.
+  ApplyImmediately: true # When you modify a DB instance, you can apply the changes immediately by setting the ApplyImmediately parameter to true. If you don't choose to apply changes immediately, the changes are put into the pending modifications queue. During the next maintenance window, any pending changes in the queue are applied. If you choose to apply changes immediately, your new changes and any changes in the pending modifications queue are applied. 
   
 ```
 

--- a/crd/crd.go
+++ b/crd/crd.go
@@ -129,6 +129,10 @@ func NewDatabaseCRD() *apiextv1beta1.CustomResourceDefinition {
 									Type:        "boolean",
 									Description: "Indicates whether to skip the creation of a final DB snapshot before deleting the instance. By default, skipfinalsnapshot isn't enabled, and the DB snapshot is created.",
 								},
+								"ApplyImmediately": {
+									Type:        "boolean",
+									Description: "When you modify a DB instance, you can apply the changes immediately by setting the ApplyImmediately parameter to true. If you don't choose to apply changes immediately, the changes are put into the pending modifications queue. During the next maintenance window, any pending changes in the queue are applied. If you choose to apply changes immediately, your new changes and any changes in the pending modifications queue are applied. ",
+								},
 							},
 						},
 					},
@@ -177,6 +181,7 @@ type DatabaseSpec struct {
 	Tags                  string               `json:"tags,omitempty"`     // key=value,key1=value1
 	Provider              string               `json:"provider,omitempty"` // local or aws
 	SkipFinalSnapshot     bool                 `json:"skipfinalsnapshot,omitempty"`
+	ApplyImmediately      bool                 `json:"ApplyImmediately,omitempty"`
 }
 
 type DatabaseStatus struct {

--- a/local/local_provider.go
+++ b/local/local_provider.go
@@ -29,6 +29,11 @@ func New(db *crd.Database, kc kubernetes.Interface, repository string) (*Local, 
 	return &r, nil
 }
 
+func (l *Local) UpdateDatabase(ctx context.Context, db *crd.Database) error {
+	_, err := l.CreateDatabase(ctx, db)
+	return err
+}
+
 // CreateDatabase creates a database from the CRD database object, is also ensures that the correct
 // subnets are created for the database so we can access it
 func (l *Local) CreateDatabase(ctx context.Context, db *crd.Database) (string, error) {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+
 	"github.com/sorenmat/k8s-rds/crd"
 )
 
@@ -9,6 +10,7 @@ import (
 // this is the main interface that should be implemented if a new provider is created
 type DatabaseProvider interface {
 	CreateDatabase(context.Context, *crd.Database) (string, error)
+	UpdateDatabase(context.Context, *crd.Database) error
 	DeleteDatabase(context.Context, *crd.Database) error
 	ServiceProvider
 }

--- a/rds/rds_provider.go
+++ b/rds/rds_provider.go
@@ -180,7 +180,9 @@ func getEndpoint(ctx context.Context, dbName *string, svc *rds.Client) (string, 
 		return "", fmt.Errorf("wasn't able to describe the db instance with id %v", dbName)
 	}
 	rdsdb := instance.DBInstances[0]
-
+	if rdsdb.Endpoint == nil || rdsdb.Endpoint.Address == nil {
+		return "", fmt.Errorf("couldn't get the endpoint for DB instance with id %v", dbName)
+	}
 	dbHostname := *rdsdb.Endpoint.Address
 	return dbHostname, nil
 }

--- a/rds/rds_provider_test.go
+++ b/rds/rds_provider_test.go
@@ -191,3 +191,43 @@ func TestConvertSpecToDeleteInput_disabled(t *testing.T) {
 	assert.Equal(t, "mydb-myns-10202020202", *input.FinalDBSnapshotIdentifier)
 	assert.Equal(t, false, input.SkipFinalSnapshot)
 }
+
+func TestConvertSpecToModifyInput_withApplyImmediately(t *testing.T) {
+	input := convertSpecToModifyInput(&crd.Database{
+		Spec: crd.DatabaseSpec{
+			MaxAllocatedSize: 50,
+			Size:             21,
+			ApplyImmediately: true,
+			Class:            "db.t3.small",
+		},
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "mydb",
+			Namespace: "myns",
+		},
+	})
+	assert.NotNil(t, input.DBInstanceIdentifier)
+	assert.Equal(t, true, input.ApplyImmediately)
+	assert.Equal(t, int32(50), *input.MaxAllocatedStorage)
+	assert.Equal(t, int32(21), *input.AllocatedStorage)
+	assert.Equal(t, "db.t3.small", *input.DBInstanceClass)
+}
+
+func TestConvertSpecToModifyInput_withoutApplyImmediately(t *testing.T) {
+	input := convertSpecToModifyInput(&crd.Database{
+		Spec: crd.DatabaseSpec{
+			MaxAllocatedSize: 50,
+			Size:             21,
+			ApplyImmediately: false,
+			Class:            "db.t3.small",
+		},
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "mydb",
+			Namespace: "myns",
+		},
+	})
+	assert.NotNil(t, input.DBInstanceIdentifier)
+	assert.Equal(t, false, input.ApplyImmediately)
+	assert.Equal(t, int32(50), *input.MaxAllocatedStorage)
+	assert.Equal(t, int32(21), *input.AllocatedStorage)
+	assert.Equal(t, "db.t3.small", *input.DBInstanceClass)
+}


### PR DESCRIPTION
This PR allows database modification. To be more specific it updates DB class type, storage size when the underlying deployment config changes.
How to test:

Create a new Database deployment and wait for the RDS to be created, once it's done, update one of size, MaxAllocatedSize or class, and apply the changes, you should see in the RDS level that the DB instance config changed.
You can also configure ApplyImmediately to either apply the changes (or any pending changes) immediately, or just queue them for the next [maintenance window](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html).