### PR TITLE
restore database instance from snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ The node running the pod should have an instance profile that allows creation an
                 "rds:DescribeDBInstances",
                 "rds:CreateDBInstance",
                 "rds:ModifyDBInstance",
-                "rds:DeleteDBInstance"
+                "rds:DeleteDBInstance",
+                "rds:DescribeDBSnapshots",
+                "rds:RestoreDBInstanceFromDBSnapshot"
             ],
             "Resource": "*"
         }

--- a/crd/crd.go
+++ b/crd/crd.go
@@ -133,6 +133,10 @@ func NewDatabaseCRD() *apiextv1beta1.CustomResourceDefinition {
 									Type:        "boolean",
 									Description: "When you modify a DB instance, you can apply the changes immediately by setting the ApplyImmediately parameter to true. If you don't choose to apply changes immediately, the changes are put into the pending modifications queue. During the next maintenance window, any pending changes in the queue are applied. If you choose to apply changes immediately, your new changes and any changes in the pending modifications queue are applied. ",
 								},
+								"DBSnapshotIdentifier": {
+									Type:        "string",
+									Description: "DB snapshot identifier to restore from.",
+								},
 							},
 						},
 					},

--- a/crd/crd.go
+++ b/crd/crd.go
@@ -182,6 +182,7 @@ type DatabaseSpec struct {
 	Provider              string               `json:"provider,omitempty"` // local or aws
 	SkipFinalSnapshot     bool                 `json:"skipfinalsnapshot,omitempty"`
 	ApplyImmediately      bool                 `json:"ApplyImmediately,omitempty"`
+	DBSnapshotIdentifier  string               `json:"DBSnapshotIdentifier,omitempty"`
 }
 
 type DatabaseStatus struct {

--- a/rds/rds_provider.go
+++ b/rds/rds_provider.go
@@ -171,7 +171,9 @@ func (r *RDS) CreateDatabase(ctx context.Context, db *crd.Database) (string, err
 	} else if err != nil {
 		return "", errors.Wrap(err, fmt.Sprintf("wasn't able to describe the db instance with id %v", input.DBInstanceIdentifier))
 	}
-	waitForDBAvailability(ctx, input.DBInstanceIdentifier, r.rdsclient())
+	if err := waitForDBAvailability(ctx, input.DBInstanceIdentifier, r.rdsclient()); err != nil {
+		return "", errors.Wrap(err, fmt.Sprintf("error while waiting for the DB %s availability", *input.DBInstanceIdentifier))
+	}
 	// Get the newly created database so we can get the endpoint
 	dbHostname, err := getEndpoint(ctx, input.DBInstanceIdentifier, r.rdsclient())
 	if err != nil {
@@ -203,7 +205,9 @@ func (r *RDS) UpdateDatabase(ctx context.Context, db *crd.Database) error {
 	} else {
 		log.Printf("Database modified and update is pending and will be executed during the next maintenance window")
 	}
-	waitForDBAvailability(ctx, input.DBInstanceIdentifier, r.rdsclient())
+	if err := waitForDBAvailability(ctx, input.DBInstanceIdentifier, r.rdsclient()); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error while waiting for the DB %s availability", *input.DBInstanceIdentifier))
+	}
 	return nil
 }
 

--- a/rds/rds_provider_test.go
+++ b/rds/rds_provider_test.go
@@ -231,3 +231,19 @@ func TestConvertSpecToModifyInput_withoutApplyImmediately(t *testing.T) {
 	assert.Equal(t, int32(21), *input.AllocatedStorage)
 	assert.Equal(t, "db.t3.small", *input.DBInstanceClass)
 }
+
+func TestConvertSpecToRestoreFromSnapshotInput(t *testing.T) {
+	input := convertSpecToRestoreFromSnapshotInput(&crd.Database{
+		Spec: crd.DatabaseSpec{
+			Class:                "db.t3.small",
+			DBSnapshotIdentifier: "dbidentifier",
+		},
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "mydb",
+			Namespace: "myns",
+		},
+	}, "mysubnet", []string{"sg-1234", "sg-4321"})
+	assert.NotNil(t, input.DBInstanceIdentifier)
+	assert.Equal(t, "db.t3.small", *input.DBInstanceClass)
+	assert.Equal(t, "dbidentifier", *input.DBSnapshotIdentifier)
+}


### PR DESCRIPTION
This PR allows to restore the DB instance from an existing snapshot, if the snapshot with the given identifier does not exist, it'll try to create it using the given config. If the DB instance with the configured name already exists it will not try to restore it.

# How to test:
Config:
```
...
spec:
  class: db.t3.small
  engine: postgres
  dbname: mypgsql
  name: mypgsql
  ...
  DBSnapshotIdentifier: "mypgsql-default-1661462171045938588"
```

Simple output:
```
2022/08/26 12:29:51 Trying to find db instance mypgsql
2022/08/26 12:29:56 DB instance mypgsql not found trying to restore it from snapshot with id: mypgsql-default-1661462171045938588
2022/08/26 12:29:57 DB Snapshot with identifier mypgsql-default-1661462171045938588 was not found trying to create new DB instance with name: mypgsql
2022/08/26 12:29:58 Waiting for db instance mypgsql-default to become available
2022/08/26 12:33:34 DB instance mypgsql-default is now available
2022/08/26 12:33:35 Creating service 'mypgsql' for mypgsql-default.ctjkfvhtcpdu.us-east-1.rds.amazonaws.com
2022/08/26 12:33:35 Seems like we are running in a Kubernetes cluster!!
2022/08/26 12:33:35 New resource version of the DB mypgsql is 80480
2022/08/26 12:33:35 Creation of database mypgsql done
```